### PR TITLE
Add language setting

### DIFF
--- a/po/argenta.pot
+++ b/po/argenta.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: argenta\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-26 11:37+0000\n"
+"POT-Creation-Date: 2023-02-08 16:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -134,7 +134,15 @@ msgstr ""
 msgid "Large"
 msgstr ""
 
-#: ../qml/SettingsPage.qml:52
+#: ../qml/SettingsPage.qml:54
+msgid "French"
+msgstr ""
+
+#: ../qml/SettingsPage.qml:54
+msgid "Dutch"
+msgstr ""
+
+#: ../qml/SettingsPage.qml:75
 msgid "Close"
 msgstr ""
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -113,7 +113,7 @@ MainView {
          ]
 
                 zoomFactor: 2.20
-                url: "https://homebank.argenta.be"
+                url: "https://homebank.argenta.be/webapp/"+appSettings.selectedLanguage
 
             onFileDialogRequested: function(request) {
 

--- a/qml/SettingsComponent.qml
+++ b/qml/SettingsComponent.qml
@@ -8,6 +8,8 @@ Item{
     property alias zoomFactor: settings.zoomFactor
     property alias argentaZoomFactor: settings.argentaZoomFactor
     property alias selectedIndex: settings.selectedIndex
+    property alias selectedLanguageIndex: settings.selectedLanguageIndex
+    property alias selectedLanguage: settings.selectedLanguage
     
     //User data
     property alias firstRun: settings.firstRun
@@ -19,6 +21,8 @@ Item{
         property real zoomFactor: 1.75
         property real argentaZoomFactor: 1.75
         property real selectedIndex: 1
+        property real selectedLanguageIndex: 0
+        property string selectedLanguage: "nl"
         
         //User data
         property bool firstRun: true

--- a/qml/SettingsPage.qml
+++ b/qml/SettingsPage.qml
@@ -11,17 +11,17 @@ Dialog {
     title: i18n.tr("Argenta settings")
 
          Component.onCompleted: {
-            selector.selectedIndex = appSettings.selectedIndex
+            zoomSelector.selectedIndex = appSettings.selectedIndex
+            languageSelector.selectedIndex = appSettings.selectedLanguageIndex
         }
 
         UT.OptionSelector {
-            id: selector
+            id: zoomSelector
             expanded: true
-            containerHeight: parent.height * 0.75
             anchors.horizontalCenter: parent.horizontalCenter
             model: [i18n.tr("Small"),i18n.tr("Normal"),i18n.tr("Large")]
             onSelectedIndexChanged: {
-                switch(selector.selectedIndex) {
+                switch(zoomSelector.selectedIndex) {
                 case 0: {
                     webview.zoomFactor = 1.25
                     appSettings.argentaZoomFactor = 1.25
@@ -47,6 +47,29 @@ Dialog {
             }
         }        
 
+        UT.OptionSelector {
+            id: languageSelector
+            expanded: true
+            anchors.horizontalCenter: parent.horizontalCenter
+            model: [i18n.tr("French"),i18n.tr("Dutch")]
+            onSelectedIndexChanged: {
+                switch(languageSelector.selectedIndex) {
+                case 0: {
+                    webview.url = "https://homebank.argenta.be/webapp/fr"
+                    appSettings.selectedLanguageIndex = 0
+                    appSettings.selectedLanguage = "fr"
+                    break;
+                }
+                case 1: {
+                    webview.url = "https://homebank.argenta.be/webapp/nl"
+                    appSettings.selectedLanguageIndex = 1
+                    appSettings.selectedLanguage = "nl"
+                    break;
+                }
+                }
+            }
+        }
+            
             Button {
                 Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
                 text: i18n.tr('Close')


### PR DESCRIPTION
Add a menu in the app settings to define the preferred language, as by default it is in Dutch, and will reset to it every time you restart the app (moreover, I didn't see any way to change the language once the cookies banner has been dismissed).

This is my first time contributing to a QML/Ubuntu Touch app, so feel free to say if something is done wrong.